### PR TITLE
updated form carousel

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -13,3 +13,9 @@ body{
 .margin100{
   margin-top: 100px;
 }
+.front {
+  z-index: 5000;
+}
+.carousel{
+  min-height: 500px;
+}

--- a/views/newStore.handlebars
+++ b/views/newStore.handlebars
@@ -1,55 +1,366 @@
-<div class="container">
+<div class="container margin100">
     <div class="carousel carousel-slider center" data-indicators="true">
         <div class="carousel-fixed-item center">
-            <a class="btn waves-effect white grey-text darken-text-2">button</a>
+            <a class="btn blue-grey darken-1" id="next-btn">Next</a>
         </div>
-        <div class="carousel-item red white-text" href="#one!">
-            <h2>First Panel</h2>
-            <p class="white-text">This is your first panel</p>
+        <div class="carousel-item white blue-grey-text darken-4-text" href="#one!">
+            <h2>SchedulEZ</h2>
+            <p class="blue-grey-text">Create an account</p>
             <div class="row">
-                <form class="col s12">
-                    <div class="row">
-                        <div class="input-field col s6">
-                            <input id="first_name" type="text" class="validate">
-                            <label for="first_name">First Name</label>
-                        </div>
-                        <div class="input-field col s6">
-                            <input id="last_name" type="text" class="validate">
-                            <label for="last_name">Last Name</label>
-                        </div>
+                <form>
+                    <div class="input-field col s8 offset-s2">
+                        <input id="company-name">
+                        <label for="company-name">Company Name</label>
+                    </div>
+                    <div class="input-field col s8 offset-s2">
+                        <input id="company-email">
+                        <label for="company-email">Primary email address</label>
                     </div>
                 </form>
             </div>
         </div>
-        <div class="carousel-item amber white-text" href="#two!">
-            <h2>Second Panel</h2>
-            <p class="white-text">This is your second panel</p>
+        <div class="carousel-item white blue-grey-text darken-4-text" href="#two!">
+            <h2>SchedulEZ</h2>
+            <p class="blue-grey-text">Primary Location or Headquarters</p>
             <div class="row">
-                <form class="col s12">
+                <form>
                     <div class="row">
-                        <div class="input-field col s12">
-                            <input id="first_name" type="text" class="validate">
-                            <label for="first_name">First Name</label>
+                        <div class="input-field col s8 offset-s2">
+                            <input id="company-street">
+                            <label for="company-street">Street Address</label>
                         </div>
                     </div>
                     <div class="row">
-                        <div class="input-field col s12">
-                            <input id="last_name" type="text" class="validate">
-                            <label for="last_name">Last Name</label>
+                        <div class="input-field col s4 offset-s2">
+                            <input id="company-city">
+                            <label for="company-city">City</label>
+                        </div>
+                        <div class="input-field col s4 ">
+                            <select class="front">
+                                <option value="" disabled selected>State</option>
+                                <option value="AL">Alabama</option>
+                                <option value="AK">Alaska</option>
+                                <option value="AZ">Arizona</option>
+                                <option value="AR">Arkansas</option>
+                                <option value="CA">California</option>
+                                <option value="CO">Colorado</option>
+                                <option value="CT">Connecticut</option>
+                                <option value="DE">Delaware</option>
+                                <option value="DC">District Of Columbia</option>
+                                <option value="FL">Florida</option>
+                                <option value="GA">Georgia</option>
+                                <option value="HI">Hawaii</option>
+                                <option value="ID">Idaho</option>
+                                <option value="IL">Illinois</option>
+                                <option value="IN">Indiana</option>
+                                <option value="IA">Iowa</option>
+                                <option value="KS">Kansas</option>
+                                <option value="KY">Kentucky</option>
+                                <option value="LA">Louisiana</option>
+                                <option value="ME">Maine</option>
+                                <option value="MD">Maryland</option>
+                                <option value="MA">Massachusetts</option>
+                                <option value="MI">Michigan</option>
+                                <option value="MN">Minnesota</option>
+                                <option value="MS">Mississippi</option>
+                                <option value="MO">Missouri</option>
+                                <option value="MT">Montana</option>
+                                <option value="NE">Nebraska</option>
+                                <option value="NV">Nevada</option>
+                                <option value="NH">New Hampshire</option>
+                                <option value="NJ">New Jersey</option>
+                                <option value="NM">New Mexico</option>
+                                <option value="NY">New York</option>
+                                <option value="NC">North Carolina</option>
+                                <option value="ND">North Dakota</option>
+                                <option value="OH">Ohio</option>
+                                <option value="OK">Oklahoma</option>
+                                <option value="OR">Oregon</option>
+                                <option value="PA">Pennsylvania</option>
+                                <option value="RI">Rhode Island</option>
+                                <option value="SC">South Carolina</option>
+                                <option value="SD">South Dakota</option>
+                                <option value="TN">Tennessee</option>
+                                <option value="TX">Texas</option>
+                                <option value="UT">Utah</option>
+                                <option value="VT">Vermont</option>
+                                <option value="VA">Virginia</option>
+                                <option value="WA">Washington</option>
+                                <option value="WV">West Virginia</option>
+                                <option value="WI">Wisconsin</option>
+                                <option value="WY">Wyoming</option>
+                            </select>
+                            <label>Select State</label>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="input-field col s4 offset-s2">
+                            <input id="company-zipcode">
+                            <label for="company-zipcode">Zipcode</label>
+                        </div>
+                        <div class="input-field col s4">
+                            <input id="company-country">
+                            <label for="company-country">Country</label>
+                        </div>
+                    </div>
+
                 </form>
             </div>
         </div>
-        <div class="carousel-item green white-text" href="#three!">
-            <h2>Third Panel</h2>
-            <p class="white-text">This is your third panel</p>
+
+        <div class="carousel-item white blue-grey-text darken-4-text" href="#three!">
+            <h2>Secondary Locations</h2>
+            <p class="margin100">Does your company have multiple locations?</p>
+            <div class="row">
+                <a href="#modal-locations" class="modal-trigger waves-effect waves-light btn blue-grey darken-1">Yes</a>
+                <a class="waves-effect waves-light btn blue-grey darken-1" id="no">No</a>
+            </div>
         </div>
-        <div class="carousel-item blue white-text" href="#four!">
-            <h2>Fourth Panel</h2>
-            <p class="white-text">This is your fourth panel</p>
+
+
+        <div class="carousel-item white blue-grey-text darken-4-text" href="#four!">
+            <h2>Confirm Company Information</h2>
+            <div class="row">
+                <p><span id="company-name-confirm"><strong>Company Name</strong></span><br>
+                    <span id="company-name-confirm">Street Address</span><br>
+                    <span id="company-city-confirm">City</span>, <span id="company-state-confirm">State</span><br>
+                    <span id="company-zipcode-confirm">Zipcode</span> <span id="company-country-confirm">Country</span></p>
+                <div class="col s8 offset-s2">
+                    <table class="highlight">
+                        <thead>
+                            <tr>
+                                <th>Location</th>
+                                <th>Address</th>
+                                <th>Hours</th>
+                            </tr>
+                        </thead>
+
+                        <tbody>
+                            <tr>
+                                <td>Location 1</td>
+                                <td><span>Street Address</span><br>
+                                    <span>City</span>, <span>State</span><br>
+                                    <span>Zipcode</span> <span>Country</span></td>
+                                <td><spam>Open</spam>- <span>Close</span></td>
+                            </tr>
+                                                        <tr>
+                                <td>Location 2</td>
+                                <td><span>Street Address</span><br>
+                                    <span>City</span>, <span>State</span><br>
+                                    <span>Zipcode</span> <span>Country</span></td>
+                                <td><spam>Open</spam>- <span>Close</span></td>
+                            </tr>
+                                                        <tr>
+                                <td>Location 3</td>
+                                <td><span>Street Address</span><br>
+                                    <span>City</span>, <span>State</span><br>
+                                    <span>Zipcode</span> <span>Country</span></td>
+                                <td><spam>Open</spam>- <span>Close</span></td>
+                            </tr>
+                            
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
+
+
+
+    <!-- Modal Structure -->
+    <div id="modal-locations" class="modal">
+        <div class="modal-content blue-grey-text darken-4-text">
+            <h2 class="center">Add Locations</h2>
+            <form>
+                <div class="row">
+                    <div class="input-field col s8 offset-s2">
+                        <input class="location-street">
+                        <label for="location-street">Street Address</label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="input-field col s4 offset-s2">
+                        <input class="location-city">
+                        <label for="location-city">City</label>
+                    </div>
+                    <div class="input-field col s4 ">
+                        <select class="front">
+                            <option value="" disabled selected>State</option>
+                            <option value="AL">Alabama</option>
+                            <option value="AK">Alaska</option>
+                            <option value="AZ">Arizona</option>
+                            <option value="AR">Arkansas</option>
+                            <option value="CA">California</option>
+                            <option value="CO">Colorado</option>
+                            <option value="CT">Connecticut</option>
+                            <option value="DE">Delaware</option>
+                            <option value="DC">District Of Columbia</option>
+                            <option value="FL">Florida</option>
+                            <option value="GA">Georgia</option>
+                            <option value="HI">Hawaii</option>
+                            <option value="ID">Idaho</option>
+                            <option value="IL">Illinois</option>
+                            <option value="IN">Indiana</option>
+                            <option value="IA">Iowa</option>
+                            <option value="KS">Kansas</option>
+                            <option value="KY">Kentucky</option>
+                            <option value="LA">Louisiana</option>
+                            <option value="ME">Maine</option>
+                            <option value="MD">Maryland</option>
+                            <option value="MA">Massachusetts</option>
+                            <option value="MI">Michigan</option>
+                            <option value="MN">Minnesota</option>
+                            <option value="MS">Mississippi</option>
+                            <option value="MO">Missouri</option>
+                            <option value="MT">Montana</option>
+                            <option value="NE">Nebraska</option>
+                            <option value="NV">Nevada</option>
+                            <option value="NH">New Hampshire</option>
+                            <option value="NJ">New Jersey</option>
+                            <option value="NM">New Mexico</option>
+                            <option value="NY">New York</option>
+                            <option value="NC">North Carolina</option>
+                            <option value="ND">North Dakota</option>
+                            <option value="OH">Ohio</option>
+                            <option value="OK">Oklahoma</option>
+                            <option value="OR">Oregon</option>
+                            <option value="PA">Pennsylvania</option>
+                            <option value="RI">Rhode Island</option>
+                            <option value="SC">South Carolina</option>
+                            <option value="SD">South Dakota</option>
+                            <option value="TN">Tennessee</option>
+                            <option value="TX">Texas</option>
+                            <option value="UT">Utah</option>
+                            <option value="VT">Vermont</option>
+                            <option value="VA">Virginia</option>
+                            <option value="WA">Washington</option>
+                            <option value="WV">West Virginia</option>
+                            <option value="WI">Wisconsin</option>
+                            <option value="WY">Wyoming</option>
+                        </select>
+                        <label>Select State</label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="input-field col s4 offset-s2">
+                        <input class="location-zipcode">
+                        <label for="location-zipcode">Zipcode</label>
+                    </div>
+                    <div class="input-field col s4">
+                        <input class="location-country">
+                        <label for="company-country">Country</label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col s4 offset-s2">
+                        <p>Shifts Start at:</p>
+                        <div class="row">
+                            <div class="input-field col s6">
+
+                                <select class="start-hour front">
+                                    <option value="" disable selected>Hour</option>
+                                    <option value="00">00</option>
+                                    <option value="01">01</option>
+                                    <option value="02">02</option>
+                                    <option value="03">03</option>
+                                    <option value="04">04</option>
+                                    <option value="05">05</option>
+                                    <option value="06">06</option>
+                                    <option value="07">07</option>
+                                    <option value="08">08</option>
+                                    <option value="09">09</option>
+                                    <option value="10">10</option>
+                                    <option value="11">11</option>
+                                    <option value="12">12</option>
+                                    <option value="13">13</option>
+                                    <option value="14">14</option>
+                                    <option value="15">15</option>
+                                    <option value="16">16</option>
+                                    <option value="17">17</option>
+                                    <option value="18">18</option>
+                                    <option value="19">19</option>
+                                    <option value="20">20</option>
+                                    <option value="21">21</option>
+                                    <option value="22">22</option>
+                                    <option value="23">23</option>
+                                </select>
+                            </div>
+                            <div class="input-field col s6">
+                                <select class="start-minute front">
+                                    <option value="" disable selected>minutes </option>
+                                    <option value="00">00</option>
+                                    <option value="15">15</option>
+                                    <option value="30">30</option>
+                                    <option value="45">45</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col s4">
+                            <p>Shifts End at:</p>
+                            <div class="row">
+                                <div class="input-field col s6">
+
+                                    <select class="start-hour front">
+                                        <option value="" disable selected>Hour</option>
+                                        <option value="00">00</option>
+                                        <option value="01">01</option>
+                                        <option value="02">02</option>
+                                        <option value="03">03</option>
+                                        <option value="04">04</option>
+                                        <option value="05">05</option>
+                                        <option value="06">06</option>
+                                        <option value="07">07</option>
+                                        <option value="08">08</option>
+                                        <option value="09">09</option>
+                                        <option value="10">10</option>
+                                        <option value="11">11</option>
+                                        <option value="12">12</option>
+                                        <option value="13">13</option>
+                                        <option value="14">14</option>
+                                        <option value="15">15</option>
+                                        <option value="16">16</option>
+                                        <option value="17">17</option>
+                                        <option value="18">18</option>
+                                        <option value="19">19</option>
+                                        <option value="20">20</option>
+                                        <option value="21">21</option>
+                                        <option value="22">22</option>
+                                        <option value="23">23</option>
+                                    </select>
+                                </div>
+                                <div class="input-field col s6">
+                                    <select class="start-minute front">
+                                        <option value="" disable selected>minutes </option>
+                                        <option value="00">00</option>
+                                        <option value="15">15</option>
+                                        <option value="30">30</option>
+                                        <option value="45">45</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+
+
+
+                    </div>
+                    <div class="center">
+                        <button class="another-location waves-effect waves-light btn blue-grey darken-1">Add
+                            Another</button>
+                        <button
+                            class="finish-location waves-effect waves-light btn blue-grey darken-1">Finished</button>
+                    </div>
+            </form>
+        </div>
+        <div class="modal-footer">
+            <a href="#!" class="modal-close waves-effect waves-green btn-flat">Close</a>
+        </div>
+    </div>
+    {{!-- modal ends --}}
+
+
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"
         integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
@@ -57,16 +368,18 @@
 
     <script>
         $(document).ready(() => {
+            $("select").formSelect();
+            $(".modal").modal();
             let carouselTest = $('.carousel').carousel();
             // let elems = document.querySelectorAll('.carousel');
             // // let instance = M.Carousel.getInstance(carouselTest);
 
-            $('.carousel.carousel-slider').carousel({
+            $(".carousel.carousel-slider").carousel({
                 fullWidth: true,
                 // indicators: true
             });
 
-            $('.btn').on("click", (e) => {
+            $("#next-btn, #no").on("click", (e) => {
                 console.log('im being clicked');
 
                 e.preventDefault();
@@ -75,4 +388,3 @@
             });
         });
     </script>
-


### PR DESCRIPTION
I added form elements to the pages of the carousel and a confirmation page.
Page 1
<img width="1057" alt="Screen Shot 2019-12-16 at 12 42 27 PM" src="https://user-images.githubusercontent.com/51139840/70933393-895f4600-2001-11ea-8284-a470e3c56e96.png">

Page 2
<img width="1096" alt="Screen Shot 2019-12-16 at 12 43 07 PM" src="https://user-images.githubusercontent.com/51139840/70933463-a09e3380-2001-11ea-8fd1-8bc2e799dfea.png">

Page 3
<img width="1138" alt="Screen Shot 2019-12-16 at 12 43 33 PM" src="https://user-images.githubusercontent.com/51139840/70933485-aeec4f80-2001-11ea-8b4c-24f064e0462e.png">

<img width="1151" alt="Screen Shot 2019-12-16 at 12 43 52 PM" src="https://user-images.githubusercontent.com/51139840/70933509-bca1d500-2001-11ea-9c90-910fbf2aded5.png">

A modal offers the users an option to add multiple locations.

A confirmation page reviews the information they've given before submitting it to the database. This doesn't seem to work well with the carousel format because it doesn't expand, so we can consider other options.

<img width="1114" alt="Screen Shot 2019-12-16 at 12 45 42 PM" src="https://user-images.githubusercontent.com/51139840/70933661-01c60700-2002-11ea-92fa-600bd2205fba.png">
